### PR TITLE
Expose a public init for `PresentationCoordinator`

### DIFF
--- a/Sources/Transmission/Sources/PresentationCoordinator.swift
+++ b/Sources/Transmission/Sources/PresentationCoordinator.swift
@@ -26,6 +26,12 @@ public struct PresentationCoordinator {
     @usableFromInline
     var dismissBlock: () -> Void
 
+    public init(isPresented: Bool, sourceView: UIView? = nil, dismissBlock: @escaping () -> Void) {
+        self.isPresented = isPresented
+        self.sourceView = sourceView
+        self.dismissBlock = dismissBlock
+    }
+
     /// Dismisses the presented view with an optional animation
     @inlinable
     public func dismiss(animation: Animation? = .default) {


### PR DESCRIPTION
For some context, I'm exploring using native SwiftUI sheets for some of our sheets and want to continue using `DismissPresentationLink` which relies on `PresentationCoordinator`.

Here is my sheet code:

```swift
struct LumaSheetModifier<Destination: View>: ViewModifier {
    var detents: Set<PresentationDetent> = .init([.large])
    var isPresented: Binding<Bool>
    var preferredCornerRadius: CGFloat? = UIScreen.preferredDisplayCornerRadius
    @ViewBuilder var destination: Destination

    @State var isInteractive = LumaSheetInteractiveDismissalDisabled.defaultValue

    func body(content: Content) -> some View {
        content
            .sheet(isPresented: isPresented) {
                destination
                    .modifier(SheetCornerRadiusModifier(cornerRadius: preferredCornerRadius ?? UIScreen.preferredDisplayCornerRadius))
                    .presentationDragIndicator(.hidden)
                    .interactiveDismissDisabled(!isInteractive)
                    .presentationDetents(detents)
                    .modifier(LumaSheetDestinationModifier(isInteractive: isInteractive))
                    .onPreferenceChange(LumaSheetInteractiveDismissalDisabled.self) { newValue in
                        isInteractive = !newValue
                    }
                    /// The `DismissPresentationLink` uses the `presentationCoordinator` so we need to make sure
                    /// that it's in the environment properly.
                    .environment(
                        \.presentationCoordinator,
                         PresentationCoordinator(
                            isPresented: isPresented.wrappedValue,
                            sourceView: nil,
                            dismissBlock: {
                                isPresented.wrappedValue = false
                            }
                        )
                    )
            }
    }
}
```